### PR TITLE
Allow use of bytebuddy with Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         
         <quarkus-quinoa.version>1.1.0</quarkus-quinoa.version>
         <quarkus-logging-manager.version>2.1.3</quarkus-logging-manager.version>
+        <jvm.args>-Dnet.bytebuddy.experimental=true</jvm.args>
     </properties>
     
     <dependencyManagement>


### PR DESCRIPTION
Allow use of bytebuddy with Java 21